### PR TITLE
Add App Store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The original concept for this extension was created by gingerbeardman, who is al
 
 You are able to define, which context menu items are added to your Safari Context Menu and which keyboard shortcut to use. We elected to use strg / ctrl as it is a rather unusual modifier on macOS
 
-# Will it be in the App Store
+# Download
 
-The ultimate goal is to provide this as a free extension in the App Store
+Available as a free extension [in the App Store](https://apps.apple.com/app/wayback/id1492499129)
 
 # Translations?
 


### PR DESCRIPTION
The Readme is still talking like this isn’t on the App Store! This adds a link out. 😄

Might be worth setting the repository website to link your web page about it, too? (it’s hidden under the little cog icon on the repo home page)
<img width="738" alt="image" src="https://user-images.githubusercontent.com/282113/92275403-e8246280-eea3-11ea-9a54-90f1b3da59cc.png">

Thanks for the welcome upgrade from the official extension!